### PR TITLE
Support single rest argument

### DIFF
--- a/src/tests/test-variable-arity.scm
+++ b/src/tests/test-variable-arity.scm
@@ -1,4 +1,3 @@
-
 (add-tests-with-string-output "lambdas with varargs"
   ;; One vararg
   [((lambda (a b . c) (prim-apply pair? c)) 1 2 3) => "#t\n"]
@@ -18,6 +17,20 @@
   [((lambda (a b . c) (prim-apply car (prim-apply cdr c))) 1 2 3 4 5) => "4\n"]
   [((lambda (a b . c) (prim-apply car (prim-apply cdr (prim-apply cdr c)))) 1 2 3 4 5) => "5\n"]
   [((lambda (a b . c) (prim-apply cdr (prim-apply cdr (prim-apply cdr c)))) 1 2 3 4 5) => "()\n"])
+
+(add-tests-with-string-output "lambdas with rest argument"
+  [((lambda ls (length ls))) => "0\n"]
+  [((lambda ls (length ls)) 1) => "1\n"]
+  [((lambda ls (length ls)) 1 2) => "2\n"]
+  [((lambda ls (length ls)) 1 2 3) => "3\n"]
+  [((lambda ls (prim-apply pair? ls))) => "#f\n"]
+  [((lambda ls (prim-apply pair? ls)) 1) => "#t\n"]
+  [((lambda ls (prim-apply pair? ls)) 1 2) => "#t\n"]
+  [((lambda ls (prim-apply pair? ls)) 1 2 3) => "#t\n"]
+  [((lambda ls (prim-apply null? ls))) => "#t\n"]
+  [((lambda ls (prim-apply null? ls)) 1) => "#f\n"]
+  [((lambda ls (prim-apply null? ls)) 1 2) => "#f\n"]
+  [((lambda ls (prim-apply null? ls)) 1 2 3) => "#f\n"])
 
 (add-tests-with-stderr-output "lambdas with varargs and wrong number of args"
   [((lambda (a b . c) (prim-apply + a b)) 1) => "Exception in system: wrong number of arguments\n"]


### PR DESCRIPTION
https://github.com/mrnugget/scheme_x86/pull/3 implemented support for `lambda` expressions with these parameters:

```scheme
((lambda (a b . rest-args) (length rest-args)) 1 2 3 4)  ;; => 2
```

This PR adds support for this form:

```scheme
((lambda rest-args (length rest-args)) 1 2 3)  ;; =>  3
```

`rest-args` will be a list of all arguments in the call.