### PR TITLE
Alpha conversion and explicit tagging of calls to builtin primitives

### DIFF
--- a/src/compiler.scm
+++ b/src/compiler.scm
@@ -1147,11 +1147,11 @@
   (define (map-transform ls env) (map (lambda (e) (transform e env)) ls))
   (define (transform expr env)
     (cond
-      [(identifier? expr) expr
-                          (or (lookup-name expr env)
-                              (and (primitive-name? expr) expr)
-                              (and (builtin-name? expr) expr)
-                              (error 'alpha-conversion (format "undefined variable ~s" expr)))]
+      [(identifier? expr)
+       (or (lookup-name expr env)
+           (and (primitive-name? expr) expr)
+           (and (builtin-name? expr) expr)
+           (error 'alpha-conversion (format "undefined variable ~s" expr)))]
       [(lambda? expr)
        (let* ([params (lambda-vars-flattened expr)]
               [new-env (bulk-extend-env params (map unique-name params) env)])

--- a/src/compiler.scm
+++ b/src/compiler.scm
@@ -1063,8 +1063,9 @@
 
   (define (map-transform ls env) (map (lambda (e) (transform e env)) ls))
 
-  (trace-define (transform expr env)
+  (define (transform expr env)
     (cond
+      [(quote? expr) expr]
       [(primitive-name? expr) `(primitive-ref ,expr)]
       [(identifier? expr)
        (or (lookup-name expr env)

--- a/src/tests/test-macro-expansion.scm
+++ b/src/tests/test-macro-expansion.scm
@@ -114,3 +114,7 @@
                                     (prim-apply string-length s2))
                                   (rec 0))))])
      (user-string-eq "foobar" "foobar")) => "#t\n"])
+
+(add-tests-with-precompiled-output "tagging builtins with prim-apply"
+  [(zero? 0) => (labels () () (prim-apply zero? 0))]
+  [(let ([x 1]) (zero? x)) => (labels () () (let ([x 1]) (prim-apply zero? x)))])

--- a/src/tests/test-macro-expansion.scm
+++ b/src/tests/test-macro-expansion.scm
@@ -26,7 +26,7 @@
    => (labels
         ()
         ()
-        (let ([result (let ([x 1]) (let ([y 2]) (prim-apply + x y)))])
+        (let ([result (let ([x_1 1]) (let ([y_1 2]) (prim-apply + x_1 y_1)))])
           (let ([z 3]) (prim-apply + result z))))]
 
   [(lambda (z) (prim-apply + z (let* ([x 1] [y 2]) (prim-apply + x y))))


### PR DESCRIPTION
This adds alpha conversion and explicit tagging of calls to builtin primitives with `(prim-apply ...)`

Here's an example what the `macro-expansion` precompilation step does now:

```scheme
> (define input '(let ([x 1]) (let ([lambda 2]) (let ([x 3]) (let ([fixnum? 3]) (+ x lambda))))))

;; Input, not precompiled
> (pretty-print input)
(let ([x 1])
  (let ([lambda 2])
    (let ([x 3]) (let ([fixnum? 3]) (+ x lambda)))))

;; Macro-expanded and alpha-converted input
> (pretty-print (precompile-macro-expansion input))
(let ([x 1])
  (let ([lambda_1 2])
    (let ([x_1 3])
      (let ([fixnum?_1 3]) (prim-apply + x_1 lambda_1)))))
```

Here we can observe that

1. alpha-conversion gives every new user-defined identifier a unique name (`x` and `x_1`)
1. alpha-conversion gives user-defined identifiers that clash with builtin forms a new unique name (`lambda_1` instead of `lambda`)
1. alpha-conversion gives user-defined identifiers that clash with builtin primitives a new unique name (`fixnum?_1` instead of `fixnum?`)
1. macro-expansion tags the call to the builtin-primitive `+` with `prim-apply`
